### PR TITLE
Ignore request logging for upload POST requests

### DIFF
--- a/app/Client/Http/HttpClient.php
+++ b/app/Client/Http/HttpClient.php
@@ -49,7 +49,17 @@ class HttpClient
 
         $this->request = $this->parseRequest($requestData);
 
-        $this->logger->logRequest($requestData, $this->request);
+        $request      = $this->request;
+        $content_type = $request->getHeader('content-type');
+
+        $is_post   = $request->getMethod() == 'POST';
+        $is_upload = $is_post && $content_type->match('multipart/form-data');
+
+        // Do not log upload requests
+
+        if (!$is_upload) {
+            $this->logger->logRequest($requestData, $this->request);
+        }
 
         $request = $this->passRequestThroughModifiers(parse_request($requestData), $proxyConnection);
 


### PR DESCRIPTION
### The problem

Right now any POST request containing a file payload is failling on my end and ends up crashing the expose client due to memory limitations. 

### The cause

This is happening because all requests seem to go through a logging process that require parsing the whole request body.

On multipart/form-data POST content this is not a very good idea since the body is likely to contain a big amount of data which the parser won't be able to handle.

### Proposed solution

Avoid logging POST upload requests.

This fixes the problem completely on my end and I'm now able to perform upload requests without issues while using expose.

If logging these requests is a necesity then another approach must be used as to only grab part of request and avoiding parsing the whole body and it is being done right now.

I hope this helps and ends up being useful for you.

### Related tickets

- https://github.com/beyondcode/expose/issues/64
