### PR TITLE
Improved support for the share command in docker

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -2,3 +2,4 @@ PORT=8080
 DOMAIN=example.com
 ADMIN_USERNAME=username
 ADMIN_PASSWORD=password
+TOKEN=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       domain: ${DOMAIN}
       username: ${ADMIN_USERNAME}
       password: ${ADMIN_PASSWORD}
+      token: ${TOKEN}
     restart: always
     volumes:
       - ./database/expose.db:/root/.expose

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+/src/expose token ${token} && sed -i -E "s|'dns'\\s?=>\\s?'.*'|'dns' => true|g" ${exposeConfigPath}
+
 sed -i "s|username|${username}|g" ${exposeConfigPath} && sed -i "s|password|${password}|g" ${exposeConfigPath}
 
 if [[ $# -eq 0 ]]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-/src/expose token ${token} && sed -i -E "s|'dns'\\s?=>\\s?'.*'|'dns' => true|g" ${exposeConfigPath}
-
 sed -i "s|username|${username}|g" ${exposeConfigPath} && sed -i "s|password|${password}|g" ${exposeConfigPath}
+
+sed -i -E "s|'dns'\\s?=>\\s?'.*'|'dns' => true|g" ${exposeConfigPath}
+
+/src/expose token ${token}
 
 if [[ $# -eq 0 ]]; then
     exec /src/expose serve ${domain} --port ${port} --validateAuthTokens


### PR DESCRIPTION
We often use expose directly from our development containers to share publicly.
This pull request will simplify this with support for the following setup:

version: '3.8'
services:
  app:
    image: php:8.0-apache
    volumes:
      - ./:/var/www/html/
  expose:
    image: beyondcodegmbh/expose-server:latest
    command: "share app --subdomain=${APP_SUBDOMAIN}"
    ports:
    - 4040:4040
    environment:
      token: ${EXPOSE_TOKEN}
