### PR TITLE
Adds Default Subdomain

### DIFF
--- a/app/Commands/ShareCommand.php
+++ b/app/Commands/ShareCommand.php
@@ -25,6 +25,7 @@ class ShareCommand extends ServerAwareCommand
         }
 
         $domain = config('expose.default_domain');
+        $subdomain = config('expose.default_subdomain');
 
         if (! is_null($this->option('server'))) {
             $domain = null;
@@ -36,13 +37,15 @@ class ShareCommand extends ServerAwareCommand
 
         if (! is_null($this->option('subdomain'))) {
             $subdomains = explode(',', $this->option('subdomain'));
-            $this->info('Trying to use custom domain: '.$subdomains[0]);
+        } elseif (! is_null($subdomain)) {
+            $subdomains = [$subdomain];
         } else {
             $host = Str::beforeLast($this->argument('host'), '.');
             $host = Str::beforeLast($host, ':');
             $subdomains = [Str::slug($host)];
-            $this->info('Trying to use custom domain: '.$subdomains[0].PHP_EOL);
         }
+
+        $this->info('Trying to use custom domain: '.$subdomains[0].PHP_EOL);
 
         (new Factory())
             ->setLoop(app(LoopInterface::class))

--- a/config/expose.php
+++ b/config/expose.php
@@ -87,6 +87,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Default Subdomain
+    |--------------------------------------------------------------------------
+    |
+    | The custom subdomain to use when sharing sites with Expose.
+    | You can reserve subdomains using Expose Pro.
+    | Learn more at: https://expose.dev/get-pro
+    |
+    */
+    'default_subdomain' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Default TLD
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
Allows users to configure a default subdomain instead of using the `--subdomain` command flag.

This is most useful when using a local project config.