### PR TITLE
fix(typo-in-docs): fixed a typo in the installation section

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -6,6 +6,7 @@ order: 1
 # Installation
 
 ## PHP Archive (PHAR)
+
 We distribute Expose as a PHAR archive that contains everything you need in order to use Expose. Simply download it from [here]() and make it executable:
 
 ```
@@ -19,12 +20,13 @@ chmod +x expose
 You most likely want to put the `expose.phar` into a directory on your `PATH`, so you can simply call expose from any directory. For example:
 
 ```
-sudo mv expose.phar /usr/local/bin/expose
+sudo mv expose /usr/local/bin/expose
 ```
 
 After that, you are ready to go and can [share your first site](/docs/expose/getting-started/sharing-your-first-site).
- 
+
 ## Via Composer
+
 Expose is a PHP application and you can install the client for your local machine as a global composer dependency:
 
 ```bash
@@ -60,7 +62,6 @@ docker run expose serve my-domain.com # start a server
 ```
 
 Now you're ready to go and can [share your first site](/docs/expose/getting-started/sharing-your-first-site).
-
 
 ### Extending Expose
 


### PR DESCRIPTION
Hi, I was setting up a new debian machine and I came across this little typo in the installation guide from expose.phar to just expose. please find the attached image

_sorry about the new line additions, vscode just did it automatically_

Thanks a lot, amazing peace of software

![Screenshot from 2022-09-06 18-57-09](https://user-images.githubusercontent.com/33263129/188696974-0cff635b-7c67-459c-b64f-c8463593f93b.png)
