### PR TITLE
Fix bin reference for PHAR compilation.

### DIFF
--- a/box.json
+++ b/box.json
@@ -16,5 +16,7 @@
     "compression": "GZ",
     "compactors": [
         "KevinGH\\Box\\Compactor\\Json"
-    ]
+    ],
+    "output": "builds/expose",
+    "main": "expose"
 }

--- a/builds/.gitignore
+++ b/builds/.gitignore
@@ -1,2 +1,3 @@
 !.gitignore
 *
+!/expose


### PR DESCRIPTION
I've gotten errors when using the compiled PHAR and it had an inflated size due to including the already present PHAR from `builds/expose`. This PR fixes the PHAR configuration to match the documented output location and to use the correct main entrypoint.