### PR TITLE
Fix ratchet/rfc6455 versions mismatch during composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "laravel-zero/phar-updater": "^1.2"
     },
     "require-dev": {
-        "cboden/ratchet": "dev-master",
+        "cboden/ratchet": "^0.4.4",
         "clue/block-react": "^1.4",
         "clue/reactphp-sqlite": "dev-modular-worker-for-phar-support",
         "guzzlehttp/guzzle": "^7.4",
@@ -69,10 +69,6 @@
         {
             "type": "git",
             "url": "https://github.com/seankndy/reactphp-sqlite"
-        },
-        {
-            "type": "git",
-            "url": "https://github.com/beyondcode/Ratchet"
         },
         {
             "type": "git",


### PR DESCRIPTION
The PR is fixing the following problem you can experience on the latest version running `composer install`:
![image](https://github.com/user-attachments/assets/b3a0d567-a4ca-4d76-8ab2-8f99d44adac4)
