### PR TITLE
Correctly load plugins, even in sub-directories.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "react/stream": "^1.1.1",
         "riverline/multipart-parser": "^2.0",
         "symfony/expression-language": "^5.2",
+        "symfony/finder": "^7.0",
         "symfony/http-kernel": "^7.0",
         "symfony/psr-http-message-bridge": "^7.0",
         "symfony/yaml": "^7.0"


### PR DESCRIPTION
Previously, any files in ~/.expose/plugins directory was loaded as a plugin.

Now, README.md files are excluded.

Also, the plugin can be in a sub-folder.
This means we can do something like:

git clone custom-expose-plugin.git

in the plugins folder and it will work